### PR TITLE
Ajuste função ask_user para funcionar em todos outros shells não apenas no BASH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,8 @@ ask_user() {
     local variable_name="$3"
     
     # Modo sempre interativo - perguntar ao usuário
-    read -p "$prompt" response
+    echo -n "$prompt: "
+    read response
     # Se resposta for vazia, usar o padrão
     response=${response:-$default}
     


### PR DESCRIPTION
Olá estou abrindo está PR para ajustar a função ask_user em outros SHELL, utilizo o ZSH e percebi que o ask_user da linha 408 não está executando. 

E isso estava impedindo a instalação do girus.
Caindo sempre no erro da linha 416, sendo impossivel instalar o girus.