### PR TITLE
Ajuste validacao docker info durante instalacao.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -223,12 +223,12 @@ install_kubectl() {
 }
 
 # Função para verificar se o Docker está em execução
-check_docker_running() {
-    if docker info &> /dev/null; then
+check_docker_running(){
+    if docker info &> /dev/null && sudo docker info &> /dev/null; then        
         return 0
-    else
-        return 1
     fi
+
+    return 1
 }
 
 # Verificar se o Girus CLI está no PATH
@@ -403,7 +403,7 @@ if ! command -v docker &> /dev/null; then
     fi
 else
     # Verificar se o Docker está em execução
-    if ! docker info &> /dev/null; then
+    if ! check_docker_running; then
         echo "⚠️ Aviso: Docker está instalado, mas não está em execução."
         ask_user "Deseja tentar iniciar o Docker? (S/n): " "S" "START_DOCKER"
         
@@ -412,12 +412,9 @@ else
             if [ "$OS" == "linux" ]; then
                 sudo systemctl start docker
                 # Verificar novamente
-                if ! docker info &> /dev/null; then
-                    # Tentativa utilizando SUDO
-                    if ! sudo docker info &> /dev/null; then
-                        echo "❌ Falha ao iniciar o Docker. Por favor, inicie manualmente com 'sudo systemctl start docker'"
-                        exit 1
-                    fi
+                if ! check_docker_running; then                                        
+                    echo "❌ Falha ao iniciar o Docker. Por favor, inicie manualmente com 'sudo systemctl start docker'"
+                    exit 1                    
                 fi
             else
                 echo "No macOS/Windows, inicie o Docker Desktop manualmente e execute este script novamente."

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,8 @@ ask_user() {
     local variable_name="$3"
     
     # Modo sempre interativo - perguntar ao usuário
-    read -p "$prompt" response
+    echo -n "$prompt: "
+    read response
     # Se resposta for vazia, usar o padrão
     response=${response:-$default}
     

--- a/install.sh
+++ b/install.sh
@@ -27,8 +27,7 @@ ask_user() {
     local variable_name="$3"
     
     # Modo sempre interativo - perguntar ao usuário
-    echo -n "$prompt: "
-    read response
+    read -p "$prompt" response
     # Se resposta for vazia, usar o padrão
     response=${response:-$default}
     

--- a/install.sh
+++ b/install.sh
@@ -223,7 +223,7 @@ install_kubectl() {
 
 # Função para verificar se o Docker está em execução
 check_docker_running(){
-    if docker info &> /dev/null && sudo docker info &> /dev/null; then        
+    if sudo docker info &> /dev/null; then        
         return 0
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -413,8 +413,11 @@ else
                 sudo systemctl start docker
                 # Verificar novamente
                 if ! docker info &> /dev/null; then
-                    echo "❌ Falha ao iniciar o Docker. Por favor, inicie manualmente com 'sudo systemctl start docker'"
-                    exit 1
+                    # Tentativa utilizando SUDO
+                    if ! sudo docker info &> /dev/null; then
+                        echo "❌ Falha ao iniciar o Docker. Por favor, inicie manualmente com 'sudo systemctl start docker'"
+                        exit 1
+                    fi
                 fi
             else
                 echo "No macOS/Windows, inicie o Docker Desktop manualmente e execute este script novamente."


### PR DESCRIPTION
Adicionado tentativa de docker info utilizando sudo caso validação sem retorne erro de acesso.

Linha 415 validação docker info.
Caso usuario utilize apenas via sudo, retorna erro e não deixa avançar para frente.

adicionado segunda validação na linha 417 resolvendo o problema.

Erro impactava na instalação do girus, mostrando a mensagem de erro: ❌ Falha ao iniciar o Docker. impedindo do usuario descobrir qual erro se trata na instalação.