### PR TITLE
Fix GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ O GIRUS oferece uma variedade de laboratórios em diferentes áreas tecnológica
 
 2. **Clone o Repositório**:
    ```bash
-   git clone https://github.com/linuxtips/girus.git
+   git clone https://github.com/badtuxx/girus-cli.git
    cd girus/girus-cli
    ```
 
@@ -330,7 +330,7 @@ O GIRUS é um projeto open-source que depende da contribuição da comunidade pa
 - Artigos sobre o uso e benefícios da plataforma
 
 ### Processo de Contribuição
-1. Fork o repositório em [GitHub](https://github.com/badtuxx/girus)
+1. Fork o repositório em [GitHub](https://github.com/badtuxx/girus-cli)
 2. Crie uma branch para sua feature (`git checkout -b feature/nova-funcionalidade`)
 3. Faça suas alterações e commit (`git commit -m 'Adiciona nova funcionalidade'`)
 4. Push para a branch (`git push origin feature/nova-funcionalidade`)
@@ -356,8 +356,8 @@ O projeto GIRUS tem um plano de desenvolvimento contínuo com os seguintes objet
 
 O projeto GIRUS oferece diferentes canais para suporte e comunicação:
 
-- **GitHub Issues**: [github.com/badtuxx/girus/issues](https://github.com/linuxtips/girus/issues)
-- **GitHub Discussions**: [github.com/badtuxx/girus/discussions](https://github.com/linuxtips/girus/discussions)
+- **GitHub Issues**: [github.com/badtuxx/girus-cli/issues](https://github.com/badtuxx/girus-cli/issues)
+- **GitHub Discussions**: [github.com/badtuxx/girus-cli/discussions](https://github.com/badtuxx/girus-cli/discussions)
 - **Discord da Comunidade**: [discord.gg/linuxtips](https://discord.gg/linuxtips)
 
 ## Licença e Atribuição

--- a/install/index.html
+++ b/install/index.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="refresh"
-        content="0; url=https://raw.githubusercontent.com/linuxtips/girus/main/girus-cli/install.sh">
+        content="0; url=https://raw.githubusercontent.com/badtuxx/girus-cli/main/install.sh">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
@@ -50,7 +50,7 @@
     </style>
     <script>
         setTimeout(function () {
-            window.location.href = "https://raw.githubusercontent.com/linuxtips/girus/main/girus-cli/install.sh";
+            window.location.href = "https://raw.githubusercontent.com/badtuxx/girus-cli/main/install.sh";
         }, 3000);
     </script>
 </head>
@@ -67,7 +67,7 @@
         curl -fsSL https://girus.linuxtips.io | bash
     </div>
     <p>
-        <a href="https://github.com/linuxtips/girus">Visite o repositório no GitHub</a>
+    <a href="https://github.com/badtuxx/girus-cli">Visite o repositório no GitHub</a>
     </p>
 </body>
 


### PR DESCRIPTION
Ainda existem outras menções a um repositório inexistente, como
o logo, mas como não achei o SVG no badtuxx/girus-cli, preferi
deixar como estava. Também existem menções no Dockerfile e
em .github/workflows, mas também preferi não alterar, por não
ter certeza se bastava nesses casos fazer a simples substituição
que fiz nos outros.

É possível encontrar as outras com `grep -iRn "linuxtips/girus" .`


Signed-off-by: Marcel Ribeiro-Dantas <mribeirodantas@seqera.io>
