### PR TITLE
fix kubectl version instruction command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -139,7 +139,7 @@ data:
         description: "Aprenda a verificar os componentes básicos de um cluster Kubernetes"
         steps:
           - "Verifique se o kubectl está instalado:"
-          - "` + "`" + `kubectl --version` + "`" + `"
+          - "` + "`" + `kubectl version` + "`" + `"
           - "Verifique os nós do cluster executando:"
           - "` + "`" + `kubectl get nodes` + "`" + `"
           - "Veja informações mais detalhadas sobre os nós:"


### PR DESCRIPTION
Ajusta a instrução do comando `kubectl --version` para `kubectl version` no lab `Laboratório: kubernetes-basics`.

Instrução:

<img width="435" alt="image" src="https://github.com/user-attachments/assets/477f3a29-60c5-4d5d-997d-e1cd1709d0f4" />


Erro do `kubectl --version`:

<img width="543" alt="image" src="https://github.com/user-attachments/assets/4cf92e72-42ba-4dff-8561-8d929dc25083" />

Output do comando `kubectl version`:

<img width="545" alt="image" src="https://github.com/user-attachments/assets/41ef0f5a-fadb-4315-80fe-8baef7cb3b3b" />

