### PR TITLE
Remove yaml format

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -169,7 +169,7 @@ data:
           - "` + "`" + `kubectl create namespace k8s-demo` + "`" + `"
           - "Crie um arquivo pod.yaml com o seguinte conteúdo:"
           - |
-            ` + "```yaml" + `
+            ` + "```" + `
             apiVersion: v1
             kind: Pod
             metadata:
@@ -635,7 +635,7 @@ data:
           - "Agora, vamos criar outro deployment usando um arquivo YAML:"
           - "Crie um arquivo deployment.yaml:"
           - |
-            ` + "```yaml" + `
+            ` + "```" + `
             apiVersion: apps/v1
             kind: Deployment
             metadata:


### PR DESCRIPTION
This is related to the issue: https://github.com/badtuxx/girus-cli/issues/37
![Screenshot 2025-04-03 at 22 34 50](https://github.com/user-attachments/assets/f9968c66-d1f2-4b38-8ebc-11e5efa8b2d0)

Removing the yaml from the file, keep the file correct and with good markdown syntax.
The way we copy, an empty line is at the top, but that is not an issue for K8s. 