### PR TITLE
Usa ARCH para obter os binários correspondentes do kind e kubectl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -192,7 +192,7 @@ install_kind() {
 
     if [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
         # Linux/Mac
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-amd64
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-${ARCH}
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
 
@@ -220,7 +220,7 @@ install_kubectl() {
 
     if [ "$OS" == "linux" ]; then
         # Linux
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
 
@@ -229,7 +229,7 @@ install_kubectl() {
         if command -v brew &> /dev/null; then
             brew install kubectl
         else
-            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/${ARCH}/kubectl"
             chmod +x kubectl
             sudo mv kubectl /usr/local/bin/
         fi


### PR DESCRIPTION
Um pequeno ajuste trocando `curl ...amd64...` por `curl ...${ARCH}...` ao fazer o download do kind e kubectl para obter os arquivos da arquitetura correspondente ao computador atual.

Por só ter acesso a amd64 não consegui testar em outras arquiteturas.