### PR TITLE
Ajustes no laboratório lab41-kubernetes-fundamentos

### DIFF
--- a/internal/templates/manifests/lab_41_kubernetes_fundamentos.yaml
+++ b/internal/templates/manifests/lab_41_kubernetes_fundamentos.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   lab.yaml: |
     name: kubernetes-fundamentos
-    title: "Introdução ao Kubernetes"
+    title: "Introdução ao Kubernetes-lab"
     description: "Aprenda comandos básicos do Kubernetes para gerenciar recursos em um cluster. Este laboratório guiado fornece uma introdução completa ao Kubernetes com explicações detalhadas de cada conceito."
     duration: 15m
     image: "linuxtips/girus-kind-single-node:0.1"
@@ -58,7 +58,7 @@ data:
           - "Agora, vamos criar um pod do Nginx. Pods são a menor unidade que pode ser implantada no Kubernetes e consistem em um ou mais containers."
           - "Crie um arquivo pod.yaml com o seguinte conteúdo:"
           - |
-            ```yaml
+            ```
             apiVersion: v1
             kind: Pod
             metadata:
@@ -115,7 +115,7 @@ data:
           - "Vamos criar um Deployment do Nginx com 3 réplicas:"
           - "Crie um arquivo deployment.yaml com o seguinte conteúdo:"
           - |
-            ```yaml
+            ```
             apiVersion: apps/v1
             kind: Deployment
             metadata:


### PR DESCRIPTION
# Ajustes no laboratório lab41-kubernetes-fundamentos

- Retirada da palavra yaml do manifesto do pod da tarefa 02

Antes
![figura01](https://github.com/user-attachments/assets/31db1af1-4545-4518-8fe5-b00501d104a1)

Depois
![image](https://github.com/user-attachments/assets/5c43ca6f-8633-4e83-a6fa-75e14700dbc5)

- Retirada da palavra yaml do manifesto do deployment da tarefa 03 

Antes
![figura02](https://github.com/user-attachments/assets/58063429-7f26-41fc-a630-5b300f118197)

Depois
![image](https://github.com/user-attachments/assets/1ffa765a-487b-4543-a2bc-a7fe0b8ab5c6)

