### PR TITLE
Corrige caminho do script de instalação no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ GIRUS (GIRUS Is Really Useful System) é uma ferramenta CLI desenvolvida pela LI
 ### Usando o script de instalação
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/badtuxx/girus-cli/main/install/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/badtuxx/girus-cli/main/install.sh | bash
 ```
 
 ### Usando o Makefile


### PR DESCRIPTION
## Problema
O comando atual de instalação retorna erro 404 porque o arquivo `install.sh` foi movido da pasta `install/` após a release v0.3.0:

```shell
curl -sSL https://raw.githubusercontent.com/badtuxx/girus-cli/main/install/install.sh | bash
```

## Erro: 
```shell
bash: line 1: 404:: command not found
```

## Solução
 Identifiquei e atualizei o caminho no README para apontar para a nova localização do script.

# Evidência
<img width="951" alt="image" src="https://github.com/user-attachments/assets/701d8d36-2787-4c3e-a391-23f630eedcd4" />


