### PR TITLE
fix: atualizar README com comando de instalação simplificado do GIRUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ GIRUS (GIRUS Is Really Useful System) é uma ferramenta CLI desenvolvida pela LI
 ### Usando o script de instalação
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/badtuxx/girus-cli/main/install/install.sh | bash
+curl -sSL girus.linuxtips.io | bash
 ```
 
 ### Usando o Makefile


### PR DESCRIPTION
Corrige o comando de instalação simplificado do GIRUS. Substitui a URL longa do GitHub raw pelo domínio girus.linuxtips.io no comando de instalação curl. O endereço antigo (https://raw.githubusercontent.com/badtuxx/girus-cli/main/install/install.sh) não existe mais.