### PR TITLE
Update deployment deletion check

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -159,13 +159,13 @@ func (k *KubernetesClient) WaitForDeploymentDeletion(ctx context.Context, namesp
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			_, err := k.clientset.CoreV1().Pods(namespace).Get(ctx, deployName, metav1.GetOptions{})
+			_, err := k.clientset.AppsV1().Deployments(namespace).Get(ctx, deployName, metav1.GetOptions{})
 			if err != nil {
 				// Se o deployment não for encontrado, significa que já foi removido
 				if errors.IsNotFound(err) {
 					return nil
 				}
-				return fmt.Errorf("erro ao : %w", err)
+				return fmt.Errorf("erro ao verificar deployment: %w", err)
 			}
 			// Deployment existe, espera pra checar novamente
 			select {


### PR DESCRIPTION
## Summary
- wait on Deployments API when checking for deletion
- improve error message

## Testing
- `GOTOOLCHAIN=local go vet ./...` *(fails: go.mod requires go >= 1.24.0)*
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_6842d39db9dc832f8fe50795821adaf3