### PR TITLE
Fix comment typo in k8s client

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -122,7 +122,7 @@ func (k *KubernetesClient) ScaleDeploy(ctx context.Context, namespace, name stri
 	return nil
 }
 
-// DeletePodGracefully remove o pod com grade period (permitindo que os containers terminem primeiro)
+// DeletePodGracefully remove o pod com grace period (permitindo que os containers terminem primeiro)
 func (k *KubernetesClient) DeleteDeployGracefully(ctx context.Context, namespace, podName string) error {
 	deletePolicy := metav1.DeletePropagationForeground
 	deleteOptions := metav1.DeleteOptions{


### PR DESCRIPTION
## Summary
- fix comment around DeleteDeployGracefully, changing `grade period` to `grace period`

## Testing
- `go vet ./...` *(fails: Forbidden)*

