### PR TITLE
Restaura secoes do readme

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -114,6 +114,33 @@ GIRUS CLI utiliza versionamiento dinámico basado en etiquetas git. Puedes verif
 3. Actualiza `index.yaml` con la información del nuevo lab.
 4. Envía un Pull Request.
 
+## Contribución y comunidad
+
+GIRUS es un proyecto de código abierto que depende de las contribuciones de la comunidad para crecer. Hay varias maneras de contribuir:
+
+### Desarrollo
+- Corrección de bugs y mejoras del código fuente
+- Implementación de nuevas funcionalidades
+- Optimización del rendimiento
+- Pruebas y garantía de calidad
+
+### Creación de contenido
+- Desarrollo de nuevos templates de laboratorio
+- Traducción de contenidos a otros idiomas
+- Elaboración de tutoriales y documentación
+
+### Divulgación
+- Compartiendo el proyecto en las redes sociales
+- Presentaciones en eventos y congresos
+- Artículos sobre el uso y beneficios de la plataforma
+
+### Proceso de contribución
+1. Fork el repositorio en [GitHub](https://github.com/badtuxx/girus)
+2. Crea una branch para tu feature (`git checkout -b feature/nueva-funcionalidad`)
+3. Realice sus cambios y commit (`git commit -m 'Añade nueva funcionalidad'`)
+4. Push a la branch (`git push origin feature/nueva-funcionalidad`)
+5. Crear un Pull Request
+
 ## Soporte y Contacto
 
 * **GitHub Issues**: [github.com/badtuxx/girus-cli/issues](https://github.com/badtuxx/girus-cli/issues)

--- a/README.md
+++ b/README.md
@@ -409,6 +409,67 @@ tasks:
         expectedOutput: "saída esperada"
         errorMessage: "Mensagem de erro personalizada"
 ```
+## Integração com Sistemas de Aprendizado
+
+O GIRUS foi criado pela LINUXtips para melhorar a experiência de aprendizado dos alunos, mas não é restrito aos alunos da LINUXtips, você pode usar o GIRUS em qualquer lugar que você precise de um ambiente prático para aprender ou testar novas tecnologias, por exemplo:
+
+1. **Complemento para Cursos Online**:
+   - Ambiente prático para reforçar conteúdo teórico
+   - Validação automatizada de exercícios
+   - Experiência hands-on sem necessidade de infraestrutura adicional
+
+2. **Treinamentos Corporativos**:
+   - Ambientes padronizados para todos os participantes
+   - Fácil distribuição de exercícios práticos
+   - Redução de custos com infraestrutura
+
+3. **Preparação para Certificações**:
+   - Simulação de ambientes similares aos exames
+   - Tarefas baseadas em syllabus oficial
+   - Feedback imediato sobre o progresso
+
+## Contribuição e Comunidade
+
+O GIRUS é um projeto open-source que depende da contribuição da comunidade para crescer. Existem várias formas de contribuir:
+
+### Desenvolvimento
+- Correção de bugs e melhorias no código-fonte
+- Implementação de novos recursos
+- Otimização de performance
+- Testes e garantia de qualidade
+
+### Criação de Conteúdo
+- Desenvolvimento de novos templates de laboratórios
+- Tradução do conteúdo para outros idiomas
+- Elaboração de tutoriais e documentação
+
+### Divulgação
+- Compartilhamento do projeto nas redes sociais
+- Apresentações em eventos e conferências
+- Artigos sobre o uso e benefícios da plataforma
+
+### Processo de Contribuição
+1. Fork o repositório em [GitHub](https://github.com/badtuxx/girus)
+2. Crie uma branch para sua feature (`git checkout -b feature/nova-funcionalidade`)
+3. Faça suas alterações e commit (`git commit -m 'Adiciona nova funcionalidade'`)
+4. Push para a branch (`git push origin feature/nova-funcionalidade`)
+5. Abra um Pull Request
+
+## Roadmap de Desenvolvimento
+
+O projeto GIRUS tem um plano de desenvolvimento contínuo com os seguintes objetivos:
+
+### Curto Prazo (3-6 meses)
+- Expansão da biblioteca de laboratórios com o Girus Hub
+- Melhorias na interface do usuário
+- Suporte a múltiplos idiomas
+- Integração com sistemas de badges/conquistas
+
+### Médio Prazo (6-12 meses)
+- Implementação de recursos colaborativos
+- Sistema de competições e desafios
+- Métricas avançadas de progresso
+- Suporte a plugins de extensão
 
 ## Suporte e Contato
 


### PR DESCRIPTION
Não encontrei no history se foram retiradas de propósito, mas readicionando as seções abaixo ( percebi pq quebrou o FAQ que apontava pra Contribuição e Comunidade):

Integração com Sistemas de Aprendizado

Contribuição e Comunidade

Roadmap de Desenvolvimento