### PR TITLE
Criar flag `--tag` para comando `create cluster`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -31,7 +31,8 @@ var (
 	skipPortForward bool
 	skipBrowser     bool
 	repoIndexURL    string
-	tag             string
+	frontendTag     string
+	backendTag      string
 )
 
 var createCmd = &cobra.Command{
@@ -42,17 +43,14 @@ var createCmd = &cobra.Command{
 	},
 }
 
-func setDeploymentTag(tag string, verboseMode bool) error {
-	fmt.Println(headerColor("Sobreescrevendo imagem dos deployments"))
+func setDeploymentTag(tag string, deployment utils.DeploymentMap, verboseMode bool) error {
 	if tag == "latest" {
 		return nil
 	}
 
-	for _, deploy := range utils.Deployments {
-		image := fmt.Sprintf("%s:%s", deploy.DockerHubImage, tag)
-		if err := k8s.UpdateContainerImage("girus", deploy.Name, deploy.ContainerName, image, verboseMode); err != nil {
-			return err
-		}
+	image := fmt.Sprintf("%s:%s", deployment.DockerHubImage, tag)
+	if err := k8s.UpdateContainerImage("girus", deployment.Name, deployment.ContainerName, image, verboseMode); err != nil {
+		return err
 	}
 
 	return nil
@@ -716,7 +714,15 @@ Por padrão, o deployment embutido no binário é utilizado.`,
 					}
 				}
 
-				if err := setDeploymentTag(tag, verboseMode); err != nil {
+				fmt.Println(headerColor("Sobreescrevendo imagem dos deployments..."))
+				backendDeployment := utils.Deployments["backend"]
+				if err := setDeploymentTag(backendTag, backendDeployment, verboseMode); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+
+				frontendDeployment := utils.Deployments["frontend"]
+				if err := setDeploymentTag(frontendTag, frontendDeployment, verboseMode); err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
@@ -893,7 +899,8 @@ func init() {
 	createClusterCmd.Flags().BoolVarP(&verboseMode, "verbose", "v", false, "Modo detalhado com output completo em vez da barra de progresso")
 	createClusterCmd.Flags().BoolVar(&skipPortForward, "skip-port-forward", false, "Não perguntar sobre configurar port-forwarding")
 	createClusterCmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, "Não abrir o navegador automaticamente")
-	createClusterCmd.Flags().StringVar(&tag, "tag", "latest", "Define quais tags do frontend e backend serão usadas na criação do cluster")
+	createClusterCmd.Flags().StringVar(&frontendTag, "frontend-tag", "latest", "Define tag do frontend a ser usada na criação do cluster")
+	createClusterCmd.Flags().StringVar(&backendTag, "backend-tag", "latest", "Define tag do backend a ser usada na criação do cluster")
 
 	createClusterCmd.Flags().StringVarP(&containerEngine, "container-engine", "e", "docker", "Engine de container (docker ou podman)")
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,6 +44,9 @@ var createCmd = &cobra.Command{
 
 func setDeploymentTag(tag string, verboseMode bool) error {
 	fmt.Println(headerColor("Sobreescrevendo imagem dos deployments"))
+	if tag == "latest" {
+		return nil
+	}
 
 	for _, deploy := range utils.Deployments {
 		image := fmt.Sprintf("%s:%s", deploy.DockerHubImage, tag)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -42,6 +42,19 @@ var createCmd = &cobra.Command{
 	},
 }
 
+func setDeploymentTag(tag string, verboseMode bool) error {
+	fmt.Println(headerColor("Sobreescrevendo imagem dos deployments"))
+
+	for _, deploy := range utils.Deployments {
+		image := fmt.Sprintf("%s:%s", deploy.DockerHubImage, tag)
+		if err := k8s.UpdateContainerImage("girus", deploy.Name, deploy.ContainerName, image, verboseMode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 var createClusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "Cria o cluster Girus",
@@ -700,6 +713,10 @@ Por padrão, o deployment embutido no binário é utilizado.`,
 					}
 				}
 
+				if err := setDeploymentTag(tag, verboseMode); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
 				// Reiniciar o backend para carregar os templates
 				fmt.Println("\n" + headerColor(common.T("Reiniciando o backend para carregar os templates...", "Reiniciando el backend para cargar las plantillas...")))
 				restartCmd := exec.Command("kubectl", "rollout", "restart", "deployment/girus-backend", "-n", "girus")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/badtuxx/girus-cli/internal/lab"
 	"github.com/badtuxx/girus-cli/internal/repo"
 	"github.com/badtuxx/girus-cli/internal/templates"
+	"github.com/badtuxx/girus-cli/utils"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,7 @@ var (
 	skipPortForward bool
 	skipBrowser     bool
 	repoIndexURL    string
+	tag             string
 )
 
 var createCmd = &cobra.Command{
@@ -871,6 +873,7 @@ func init() {
 	createClusterCmd.Flags().BoolVarP(&verboseMode, "verbose", "v", false, "Modo detalhado com output completo em vez da barra de progresso")
 	createClusterCmd.Flags().BoolVarP(&skipPortForward, "skip-port-forward", "", false, "Não perguntar sobre configurar port-forwarding")
 	createClusterCmd.Flags().BoolVarP(&skipBrowser, "skip-browser", "", false, "Não abrir o navegador automaticamente")
+	createClusterCmd.Flags().StringVar(&tag, "tag", "latest", "Define quais tags do frontend e backend serão usadas na criação do cluster")
 
 	createClusterCmd.Flags().StringVarP(&containerEngine, "container-engine", "e", "docker", "Engine de container (docker ou podman)")
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -871,8 +871,8 @@ func init() {
 	// Flags para createClusterCmd
 	createClusterCmd.Flags().StringVarP(&deployFile, "file", "f", "", "Arquivo YAML para deployment do Girus (opcional)")
 	createClusterCmd.Flags().BoolVarP(&verboseMode, "verbose", "v", false, "Modo detalhado com output completo em vez da barra de progresso")
-	createClusterCmd.Flags().BoolVarP(&skipPortForward, "skip-port-forward", "", false, "Não perguntar sobre configurar port-forwarding")
-	createClusterCmd.Flags().BoolVarP(&skipBrowser, "skip-browser", "", false, "Não abrir o navegador automaticamente")
+	createClusterCmd.Flags().BoolVar(&skipPortForward, "skip-port-forward", false, "Não perguntar sobre configurar port-forwarding")
+	createClusterCmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, "Não abrir o navegador automaticamente")
 	createClusterCmd.Flags().StringVar(&tag, "tag", "latest", "Define quais tags do frontend e backend serão usadas na criação do cluster")
 
 	createClusterCmd.Flags().StringVarP(&containerEngine, "container-engine", "e", "docker", "Engine de container (docker ou podman)")

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -26,6 +26,7 @@ import (
 var (
 	green = color.New(color.FgGreen).SprintFunc()
 	bold  = color.New(color.Bold).SprintFunc()
+	k     = "kubectl"
 )
 
 // KubernetesClient wraper do cliente Kubernetes
@@ -353,6 +354,23 @@ func (k *KubernetesClient) CreateDeployment(ctx context.Context, namespace, name
 		return fmt.Errorf("falha ao criar o deploy %s no namespace %s: %w", name, namespace, err)
 	}
 	fmt.Printf("%s: Deploy %s criado com sucesso!\n", green("SUCESSO:"), bold(name))
+	return nil
+}
+
+// Atualiza imagem de um container específico dentro de um deployment.
+func UpdateContainerImage(namespace, deployment, containerName, image string, verboseMode bool) error {
+	updateArgs := []string{"set", "image", deployment, fmt.Sprintf("%s=%s", containerName, image), "-n", namespace}
+	commandString := fmt.Sprint(strings.Join(updateArgs, " "))
+	if verboseMode {
+		fmt.Printf("Executando comando %s %s\n", k, commandString)
+	}
+
+	kubectlUpdateCmd := exec.Command(k, updateArgs...)
+	var stderr bytes.Buffer
+	kubectlUpdateCmd.Stderr = &stderr
+	if err := kubectlUpdateCmd.Run(); err != nil {
+		return fmt.Errorf("falha ao reiniciar deployment [%s] no namespace [%s]: %s", deployment, namespace, stderr.String())
+	}
 	return nil
 }
 

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -369,7 +369,7 @@ func UpdateContainerImage(namespace, deployment, containerName, image string, ve
 	var stderr bytes.Buffer
 	kubectlUpdateCmd.Stderr = &stderr
 	if err := kubectlUpdateCmd.Run(); err != nil {
-		return fmt.Errorf("falha ao reiniciar deployment [%s] no namespace [%s]: %s", deployment, namespace, stderr.String())
+		return fmt.Errorf("falha ao atualizar imagem do deployment [%s] no namespace [%s]: %s", deployment, namespace, stderr.String())
 	}
 	return nil
 }

--- a/utils/deployments.go
+++ b/utils/deployments.go
@@ -1,0 +1,11 @@
+package utils
+
+type deployment struct {
+	Name           string
+	ContainerName  string
+	DockerHubImage string
+}
+
+var Deployments = []deployment{
+	{Name: "deployment/girus-frontend", ContainerName: "frontend", DockerHubImage: "linuxtips/girus-frontend"},
+	{Name: "deployment/girus-backend", ContainerName: "backend", DockerHubImage: "linuxtips/girus-backend"}}

--- a/utils/deployments.go
+++ b/utils/deployments.go
@@ -1,11 +1,12 @@
 package utils
 
-type deployment struct {
+type DeploymentMap struct {
 	Name           string
 	ContainerName  string
 	DockerHubImage string
 }
 
-var Deployments = []deployment{
-	{Name: "deployment/girus-frontend", ContainerName: "frontend", DockerHubImage: "linuxtips/girus-frontend"},
-	{Name: "deployment/girus-backend", ContainerName: "backend", DockerHubImage: "linuxtips/girus-backend"}}
+var Deployments = map[string]DeploymentMap{
+	"frontend": {Name: "deployment/girus-frontend", ContainerName: "frontend", DockerHubImage: "linuxtips/girus-frontend"},
+	"backend":  {Name: "deployment/girus-backend", ContainerName: "backend", DockerHubImage: "linuxtips/girus-backend"},
+}


### PR DESCRIPTION
Workaround que implementei ao encontrar a Issue https://github.com/badtuxx/girus-cli/issues/171.

Permite que o usuário defina a `tag` das imagens `linuxtips/girus-frontend` e `linuxtips/girus-backend` e mantém `latest` como padrão. Acho interessante ser implementado porque evita a modificação dos manifestos YAML dos deployments, e permite o uso do `girus` caso haja algum problema nas imagens mais recentes.

## Teste
```
❯ ./dist/girus create cluster --help             
cluster - Cria o cluster Girus

[...]
Flags:
      --tag string                Define quais tags do frontend e backend serão usadas na criação do cluster (default "latest")
  -v, --verbose                   Modo detalhado com output completo em vez da barra de progresso
[...]
```

```
❯ ./dist/girus create cluster --tag 0.1 --verbose

[...]
Sobreescrevendo imagem dos deployments
Executando comando kubectl set image deployment/girus-frontend frontend=linuxtips/girus-frontend:0.1 -n girus
Executando comando kubectl set image deployment/girus-backend backend=linuxtips/girus-backend:0.1 -n girus

[...]

Abrindo navegador com o Girus...

────────────────────────────────────────────────────────────
GIRUS PRONTO PARA USO!
────────────────────────────────────────────────────────────
PRÓXIMOS PASSOS:
  • Acesse o Girus no navegador:
    http://localhost:8000

  • Para aplicar mais templates de laboratórios com o Girus:
    girus create lab -f caminho/para/lab.yaml

  • Para ver todos os laboratórios disponíveis:
    girus list labs
────────────────────────────────────────────────────────────
```

```
❯ k describe deploy girus-{frontend,backend} | rg -i image
    Image:        linuxtips/girus-frontend:0.1
    Image:      linuxtips/girus-backend:0.1
```

## Dúvidas
1. Devo adicionar tradução em espanhol para a flag e logs neste PR?
2. Devo adicionar esta configuração no `~/.girus/config.yaml`?