### PR TITLE
fix(templates): usa path.Join para acessar manifestos embutidos (corrige Windows)

### DIFF
--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"embed"
 	"io/fs"
+	"path"
 	"path/filepath"
 
 	"github.com/badtuxx/girus-cli/internal/common"
@@ -16,7 +17,9 @@ func GetManifest(name string) ([]byte, error) {
 	if common.Lang() == "es" {
 		dir = "manifests_es"
 	}
-	return fs.ReadFile(ManifestFS, filepath.Join(dir, name))
+	// embed.FS sempre usa "/" como separador, independente do SO.
+	// Usar path.Join (não filepath.Join) garante o caminho correto no Windows.
+	return fs.ReadFile(ManifestFS, path.Join(dir, name))
 }
 
 // ListManifests retorna uma lista de nomes de todos os arquivos YAML no diretório de manifests


### PR DESCRIPTION
## Problema

No **Windows**, `girus create cluster` cria o cluster Kind mas falha ao implantar o Girus com:

```
ERRO: Erro ao carregar o template: open manifests\defaultDeployment.yaml: file does not exist
```

O mesmo afeta o carregamento de laboratórios (`GetManifest`).

## Causa

Em `internal/templates/templates.go`, o acesso aos manifestos embutidos (`go:embed`) usa `filepath.Join`:

```go
return fs.ReadFile(ManifestFS, filepath.Join(dir, name))
```

`filepath.Join` usa o separador do SO — no Windows gera `manifests\defaultDeployment.yaml` (barra invertida). Mas `embed.FS`/`io/fs` **sempre** usam `/` como separador, independente do sistema operacional ([doc `io/fs`](https://pkg.go.dev/io/fs#ValidPath)). Assim, no Windows o `fs.ReadFile` recebe um caminho inválido e retorna "file does not exist", mesmo com o arquivo embutido no binário.

No Linux/macOS `filepath.Join` já usa `/`, por isso o bug não aparece nessas plataformas.

## Correção

Trocar `filepath.Join` por `path.Join` (que sempre usa `/`) no acesso à `embed.FS`. Os demais usos de `filepath.Join` no projeto operam sobre o filesystem real do SO e foram mantidos.

```go
// embed.FS sempre usa "/" como separador, independente do SO.
return fs.ReadFile(ManifestFS, path.Join(dir, name))
```

## Teste

Testado no **Windows 11** com o binário recompilado:

- `girus create cluster` → implanta backend + frontend com sucesso (pods `Running`)
- `girus list labs` → lista os laboratórios normalmente
- Sem regressão no Linux (comportamento idêntico, já que `path.Join` e `filepath.Join` produzem `/` lá)

Mudança de 1 linha (+ import `path` e um comentário).